### PR TITLE
Fix fuzzy matching dependency and catalog path

### DIFF
--- a/src/dialogue_system.py
+++ b/src/dialogue_system.py
@@ -5,7 +5,9 @@ import random
 from src.nlp.fuzzy_match import fuzzy_match_style, fuzzy_match_category
 
 model = joblib.load("../models/expanded_intent_classifier_v4.pkl")
-catalog = pd.read_csv("../data/product_catalog_100_items.csv")
+# The original code referenced ``product_catalog_100_items.csv`` which does not
+# exist in the repository.  Use the available sample catalog instead.
+catalog = pd.read_csv("../data/Shopping_product_catalog.csv")
 
 context = {"category": None, "style": None, "max_price": None}
 awaiting_confirmation = False

--- a/src/nlp/fuzzy_match.py
+++ b/src/nlp/fuzzy_match.py
@@ -1,5 +1,43 @@
 
-from fuzzywuzzy import fuzz
+"""Lightweight fuzzy matching utilities used by the dialogue system.
+
+This module originally depended on the external ``fuzzywuzzy`` package.  The
+environment used for running the assistant does not always have that
+dependency available and we cannot install it without internet access.  To keep
+the code self‑contained we implement a very small subset of the functionality
+that we need here.
+"""
+
+from difflib import SequenceMatcher
+
+
+def _partial_ratio(a: str, b: str) -> int:
+    """Return a similarity score between 0 and 100 for substrings.
+
+    This is a tiny replacement for :func:`fuzzywuzzy.fuzz.partial_ratio`.  It
+    looks for the best matching substring of ``b`` against ``a`` and returns the
+    match ratio as a percentage.
+    """
+
+    if not a or not b:
+        return 0
+
+    a = a.lower()
+    b = b.lower()
+    if len(a) > len(b):
+        a, b = b, a
+
+    max_ratio = 0.0
+    len_a = len(a)
+    for i in range(len(b) - len_a + 1):
+        sub = b[i : i + len_a]
+        ratio = SequenceMatcher(None, a, sub).ratio()
+        if ratio > max_ratio:
+            max_ratio = ratio
+        if max_ratio == 1.0:
+            break
+
+    return int(round(max_ratio * 100))
 
 STYLE_KEYWORDS = {
     "casual": [
@@ -39,18 +77,22 @@ CATEGORY_KEYWORDS = {
     ]
 }
 
-def fuzzy_match_style(text):
+def fuzzy_match_style(text: str) -> str | None:
+    """Attempt to infer a style from ``text`` using fuzzy matching."""
+
     text = text.lower()
     for style, synonyms in STYLE_KEYWORDS.items():
         for word in synonyms:
-            if fuzz.partial_ratio(word, text) >= 80:
+            if _partial_ratio(word, text) >= 80:
                 return style
     return None
 
-def fuzzy_match_category(text):
+def fuzzy_match_category(text: str) -> str | None:
+    """Attempt to infer a product category from ``text``."""
+
     text = text.lower()
     for cat, synonyms in CATEGORY_KEYWORDS.items():
         for word in synonyms:
-            if fuzz.partial_ratio(word, text) >= 80:
+            if _partial_ratio(word, text) >= 80:
                 return cat
     return None


### PR DESCRIPTION
## Summary
- avoid using `fuzzywuzzy`; implement a small partial-ratio function instead
- update product catalog path in `dialogue_system.py`

## Testing
- `python3 -m py_compile src/nlp/fuzzy_match.py src/dialogue_system.py`
- `python3 src/dialogue_system.py` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_687a3ef6aadc832fa0e6a9576e3ef0f1